### PR TITLE
Add span fields to events

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,8 @@ struct SerializedEvent<'a> {
     event: SerializeEventFieldMapStrippingLog<'a>,
     #[serde(flatten)]
     extra_fields: &'a HashMap<String, String>,
+    #[serde(flatten)]
+    span_fields: serde_json::Map<String, serde_json::Value>,
     _spans: &'a [&'a str],
     _target: &'a str,
     _module_path: Option<&'a str>,
@@ -262,6 +264,7 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> tracing_subscriber::Layer<S> for La
             message: serde_json::to_string(&SerializedEvent {
                 event: SerializeEventFieldMapStrippingLog(event),
                 extra_fields: &self.extra_fields,
+                span_fields,
                 _spans: &spans,
                 _target: meta.target(),
                 _module_path: meta.module_path(),


### PR DESCRIPTION
I noticed that the fields on spans weren't appearing in Loki when I could see them in the console output while testing. Had a look in the code and saw that the span fields were being accumulated but were not sent along with the rest of the event data.