### PR TITLE
Use original level strings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,10 +380,10 @@ impl BackgroundTask {
     ) -> Result<BackgroundTask, Error> {
         fn level_str(level: Level) -> &'static str {
             match level {
-                Level::TRACE => "debug",
-                Level::DEBUG => "informational",
-                Level::INFO => "notice",
-                Level::WARN => "warning",
+                Level::TRACE => "trace",
+                Level::DEBUG => "debug",
+                Level::INFO => "info",
+                Level::WARN => "warn",
                 Level::ERROR => "error",
             }
         }


### PR DESCRIPTION
The `level_str` breaks the color coding of log levels e.g. in Grafana. Using the original `as_str` from `tracing_core::Level` fixes this issue.