### PR TITLE
Join a relative loki URL to allow prefixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,7 @@ impl BackgroundTask {
         Ok(BackgroundTask {
             receiver: ReceiverStream::new(receiver),
             loki_url: loki_url
-                .join("/loki/api/v1/push")
+                .join("loki/api/v1/push")
                 .map_err(|_| Error(ErrorI::InvalidLokiUrl))?,
             queues: LevelMap::try_from_fn(|level| {
                 labels.insert("level".into(), level_str(level).into());


### PR DESCRIPTION
This allow one to move loki behind a reverse-proxy on another path:

```rust
    let (layer, task) = tracing_loki::layer(
        Url::parse("http://127.0.0.1:3100/my/very/other/path/to/loki/").unwrap(),
        vec![("host".into(), "mine".into())].into_iter().collect(),
        vec![].into_iter().collect(),
    )?;
```