### PR TITLE
Support for Multi-tenancy in Loki

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ async fn main() -> Result<(), tracing_loki::Error> {
         Url::parse("http://127.0.0.1:3100").unwrap(),
         vec![("host".into(), "mine".into())].into_iter().collect(),
         vec![].into_iter().collect(),
+        None   // Tenant id that is passed as X-Scope-OrgID Header value to support multi-tenancy if enabled
     )?;
 
     // We need to register our layer with `tracing`.

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -13,7 +13,7 @@ fn tracing_setup() -> Result<(), Box<dyn Error>> {
         Url::parse("http://127.0.0.1:3100").unwrap(),
         vec![("host".into(), "mine".into())].into_iter().collect(),
         vec![].into_iter().collect(),
-        Some(String::from("1"))
+        Some(String::from("tenant1"))
     )?;
     tracing_subscriber::registry()
         .with(LevelFilter::INFO)

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -13,6 +13,7 @@ fn tracing_setup() -> Result<(), Box<dyn Error>> {
         Url::parse("http://127.0.0.1:3100").unwrap(),
         vec![("host".into(), "mine".into())].into_iter().collect(),
         vec![].into_iter().collect(),
+        Some(String::from("1"))
     )?;
     tracing_subscriber::registry()
         .with(LevelFilter::INFO)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,6 +530,7 @@ impl Future for BackgroundTask {
                     async move {
                         request_builder
                             .header(reqwest::header::CONTENT_TYPE, "application/x-snappy")
+                            .header(String::from("X-Scope-OrgID"), "tenant1")
                             .body(body)
                             .send()
                             .await?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,8 +404,7 @@ impl BackgroundTask {
         if let Some(tenant_id) = tenant_id {
             default_headers.insert(
                 "X-Scope-OrgID",
-                // This is guarenteed to be a UTF-8 string so its safe to unwrap the result
-                // Could panic if the input is longer then the limit of HeaderValue
+                // Could panic if the input contains invisible ASCII Characters outside of range: 32-127
                 reqwest::header::HeaderValue::from_str(tenant_id.as_str()).unwrap());
         }
         Ok(BackgroundTask {


### PR DESCRIPTION
One thing i am not sure about is this

        if let Some(tenant_id) = tenant_id {
            default_headers.insert(
                "X-Scope-OrgID",
                // Could panic if the input contains invisible ASCII Characters outside of range: 32-127
                reqwest::header::HeaderValue::from_str(tenant_id.as_str()).unwrap());
        }

I wonder if we schoud escape invisible ASCII Characters, which is not a code problem but could produce unpredictable tenant_id that is use as the header value.
If that is okey i have no problem adding the ASCII escape version

Thanks Sam