### PR TITLE
Add support for dynamic labels (where the value is obtained from tracing fields)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,10 @@ url = "2.2.2"
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 
 [features]
-default = ["compat-0-2-1", "native-tls"]
+default = ["compat-0-2-1", "native-tls", "dynamic_labels"]
 compat-0-2-1 = []
 
 native-tls = ["reqwest/native-tls"]
 rustls = ["reqwest/rustls-tls"]
+
+dynamic_labels = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,10 @@ url = "2.2.2"
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 
 [features]
-default = ["compat-0-2-1", "native-tls", "dynamic_labels"]
+default = ["compat-0-2-1", "native-tls", "dynamic-labels"]
 compat-0-2-1 = []
 
 native-tls = ["reqwest/native-tls"]
 rustls = ["reqwest/rustls-tls"]
 
-dynamic_labels = []
+dynamic-labels = []

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -166,9 +166,10 @@ impl Builder {
     /// values. For example, `"environment"` with values `"ci"`,
     /// `"development"`, `"staging"` or `"production"` would work well.
     ///
-    /// For open categories, extra fields are a better fit. See
-    /// [`Builder::extra_field`].
-    ///
+    /// For open categories, simple fields are a better fit. If you don't register
+    /// your tracing fields as dynamic labels using this method,
+    /// they will be sent as simple fields.
+    /// 
     /// # Example
     ///
     /// ```

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -76,7 +76,7 @@ impl Builder {
     ) -> Result<Builder, Error> {
         let label = ValidatedLabel::new(key.into())?;
 
-        #[cfg(feature = "dynamic_labels")]
+        #[cfg(feature = "dynamic-labels")]
         if self.dynamic_labels.contains(&label) {
             return Err(Error(ErrorI::DuplicateLabel(label.inner().to_owned())));
         }
@@ -154,7 +154,7 @@ impl Builder {
         }
         Ok(self)
     }
-    #[cfg(feature = "dynamic_labels")]
+    #[cfg(feature = "dynamic-labels")]
     /// Add a dynamic label to the logs sent to Loki through the built `Layer`.
     /// When a tracing field with the same name is present in an event, its value will be
     /// sent as a label, instead of a field.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,5 @@
 use super::event_channel;
+use super::labels::ValidatedLabel;
 use super::BackgroundTask;
 use super::BackgroundTaskController;
 use super::Error;
@@ -7,6 +8,7 @@ use super::FormattedLabels;
 use super::Layer;
 use std::collections::hash_map;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use url::Url;
 
 /// Create a [`Builder`] for constructing a [`Layer`] and its corresponding
@@ -23,6 +25,7 @@ pub fn builder() -> Builder {
         labels: FormattedLabels::new(),
         extra_fields: HashMap::new(),
         http_headers,
+        dynamic_labels: HashSet::new(),
     }
 }
 
@@ -35,6 +38,7 @@ pub struct Builder {
     labels: FormattedLabels,
     extra_fields: HashMap<String, String>,
     http_headers: reqwest::header::HeaderMap,
+    dynamic_labels: HashSet<ValidatedLabel>,
 }
 
 impl Builder {
@@ -70,7 +74,14 @@ impl Builder {
         key: S,
         value: T,
     ) -> Result<Builder, Error> {
-        self.labels.add(key.into(), value.as_ref())?;
+        let label = ValidatedLabel::new(key.into())?;
+
+        #[cfg(feature = "dynamic_labels")]
+        if self.dynamic_labels.contains(&label) {
+            return Err(Error(ErrorI::DuplicateLabel(label.inner().to_owned())));
+        }
+
+        self.labels.add(label, value.as_ref())?;
         Ok(self)
     }
     /// Set an extra field that is sent with all log records sent to Loki
@@ -143,6 +154,44 @@ impl Builder {
         }
         Ok(self)
     }
+    #[cfg(feature = "dynamic_labels")]
+    /// Add a dynamic label to the logs sent to Loki through the built `Layer`.
+    /// When a tracing field with the same name is present in an event, its value will be
+    /// sent as a label, instead of a field.
+    ///
+    /// This requires the `dynamic_labels` feature to be enabled.
+    ///
+    /// Like the static labels added with [`Builder::label`],
+    /// dynamic labels are supposed to be closed categories with few possible
+    /// values. For example, `"environment"` with values `"ci"`,
+    /// `"development"`, `"staging"` or `"production"` would work well.
+    ///
+    /// For open categories, extra fields are a better fit. See
+    /// [`Builder::extra_field`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use tracing_loki::Error;
+    /// # fn main() -> Result<(), Error> {
+    /// let builder = tracing_loki::builder()
+    ///     // Set the tenant ID for Loki.
+    ///     .dynamic_label("event_category")?;
+    /// tracing::error!(event_category = "my_category", "This is an error");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn dynamic_label<S: Into<String>>(mut self, key: S) -> Result<Builder, Error> {
+        let label = ValidatedLabel::new(key.into())?;
+        if self.labels.contains(&label) {
+            return Err(Error(ErrorI::DuplicateLabel(label.inner().to_owned())));
+        }
+        if let Some(existing) = self.dynamic_labels.replace(label) {
+            // Need to use the old value for the error message... all others are moved out.
+            return Err(Error(ErrorI::DuplicateLabel(existing.inner().to_owned())));
+        }
+        Ok(self)
+    }
     /// Build the tracing [`Layer`] and its corresponding [`BackgroundTask`].
     ///
     /// The `loki_url` is the URL of the Loki server, like
@@ -159,10 +208,16 @@ impl Builder {
     /// See the crate's root documentation for an example.
     pub fn build_url(self, loki_url: Url) -> Result<(Layer, BackgroundTask), Error> {
         let (sender, receiver) = event_channel();
+        let dynamic_labels = self
+            .dynamic_labels
+            .into_iter()
+            .map(|label| (label.inner().to_owned(), label))
+            .collect();
         Ok((
             Layer {
                 sender,
                 extra_fields: self.extra_fields,
+                dynamic_labels,
             },
             BackgroundTask::new(loki_url, self.http_headers, receiver, &self.labels)?,
         ))
@@ -190,10 +245,16 @@ impl Builder {
         loki_url: Url,
     ) -> Result<(Layer, BackgroundTaskController, BackgroundTask), Error> {
         let (sender, receiver) = event_channel();
+        let dynamic_labels = self
+            .dynamic_labels
+            .into_iter()
+            .map(|label| (label.inner().to_owned(), label))
+            .collect();
         Ok((
             Layer {
                 sender: sender.clone(),
                 extra_fields: self.extra_fields,
+                dynamic_labels,
             },
             BackgroundTaskController { sender },
             BackgroundTask::new(loki_url, self.http_headers, receiver, &self.labels)?,

--- a/src/label_map.rs
+++ b/src/label_map.rs
@@ -1,0 +1,29 @@
+use std::collections::hash_map;
+use std::collections::HashMap;
+
+#[derive(Default, Debug)]
+pub struct LabelMap<T> {
+    map: HashMap<String, T>,
+}
+
+impl<T> LabelMap<T> {
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    pub fn get_or_insert(&mut self, key: String, builder: impl FnOnce() -> T) -> &mut T {
+        // Due to borrow checker limitations around &mut, this has to accept a String
+        // instead of a &str. I tried.
+        self.map.entry(key).or_insert_with(builder)
+    }
+
+    pub fn values(&self) -> hash_map::Values<'_, String, T> {
+        self.map.values()
+    }
+
+    pub fn values_mut(&mut self) -> hash_map::ValuesMut<'_, String, T> {
+        self.map.values_mut()
+    }
+}

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -1,8 +1,12 @@
 use std::collections::HashSet;
-use std::collections::HashMap;
 use std::fmt::Write as _;
 use tracing_core::Level;
+
+#[allow(unused)]
 use tracing_core::field::Visit;
+
+#[allow(unused)]
+use std::collections::HashMap;
 
 use super::Error;
 use super::ErrorI;
@@ -39,9 +43,13 @@ impl FormattedLabels {
         }
         Ok(())
     }
+    
+    #[cfg(feature = "dynamic-labels")]
     pub fn contains(&self, ValidatedLabel(key): &ValidatedLabel) -> bool {
         self.seen_keys.contains(key)
     }
+
+    #[cfg(feature = "dynamic-labels")]
     /// Join with another set of labels that are already formatted.
     /// Does not check that the other labels are valid or that they don't contain duplicates
     /// including with the current set of labels. That is checked by the builder.
@@ -103,12 +111,14 @@ impl ValidatedLabel {
     }
 }
 
+#[cfg(feature = "dynamic-labels")]
 #[derive(Clone)]
 pub struct LabelSelectorVisitor<'a> {
     select_keys: &'a HashMap<String, ValidatedLabel>,
     found_labels: Vec<(ValidatedLabel, String)>
 }
 
+#[cfg(feature = "dynamic-labels")]
 impl<'a> LabelSelectorVisitor<'a> {
     pub fn new(select_keys: &'a HashMap<String, ValidatedLabel>) -> Self {
         Self {
@@ -130,6 +140,7 @@ impl<'a> LabelSelectorVisitor<'a> {
     }
 }
 
+#[cfg(feature = "dynamic-labels")]
 impl<'a> Visit for LabelSelectorVisitor<'a> {
     fn record_debug(&mut self, field: &tracing_core::Field, value: &dyn std::fmt::Debug) {
         if let Some(validated) = self.select_keys.get(field.name()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ use tracing_core::span::Attributes;
 use tracing_core::span::Id;
 use tracing_core::span::Record;
 use tracing_core::Event;
+#[allow(unused)]
 use tracing_core::Level;
 use tracing_core::Subscriber;
 use tracing_log::NormalizeEvent;
@@ -85,19 +86,31 @@ use tracing_subscriber::registry::LookupSpan;
 use url::Url;
 
 use labels::FormattedLabels;
-use level_map::LevelMap;
-use log_support::SerializeEventFieldMapStrippingLog;
+use labels::LabelSelectorVisitor;
+use labels::ValidatedLabel;
+use log_support::SerializeEventFieldMapStrippingLogAndKeys;
 use no_subscriber::NoSubscriber;
 use ErrorInner as ErrorI;
+
+#[cfg(not(feature = "dynamic_labels"))]
+use level_map::LevelMap;
+
+#[cfg(feature = "dynamic_labels")]
+use label_map::LabelMap;
 
 pub use builder::builder;
 pub use builder::Builder;
 
 mod builder;
 mod labels;
-mod level_map;
 mod log_support;
 mod no_subscriber;
+
+#[cfg(not(feature = "dynamic_labels"))]
+mod level_map;
+
+#[cfg(feature = "dynamic_labels")]
+mod label_map;
 
 #[cfg(doctest)]
 #[doc = include_str!("../README.md")]
@@ -107,7 +120,7 @@ fn event_channel() -> (
     mpsc::Sender<Option<LokiEvent>>,
     mpsc::Receiver<Option<LokiEvent>>,
 ) {
-    mpsc::channel(512)
+    mpsc::channel(16384) // make it so big that if we drop events, it's already kind of bad
 }
 
 /// The error type for constructing a [`Layer`].
@@ -231,19 +244,25 @@ pub fn layer(
 pub struct Layer {
     extra_fields: HashMap<String, String>,
     sender: mpsc::Sender<Option<LokiEvent>>,
+    dynamic_labels: HashMap<String, ValidatedLabel>,
 }
 
 struct LokiEvent {
     trigger_send: bool,
     timestamp: SystemTime,
-    level: Level,
     message: String,
+
+    #[cfg(not(feature = "dynamic_labels"))]
+    level: Level,
+
+    #[cfg(feature = "dynamic_labels")]
+    formatted_labels: String,
 }
 
 #[derive(Serialize)]
 struct SerializedEvent<'a> {
     #[serde(flatten)]
-    event: SerializeEventFieldMapStrippingLog<'a>,
+    event: SerializeEventFieldMapStrippingLogAndKeys<'a>,
     #[serde(flatten)]
     extra_fields: &'a HashMap<String, String>,
     #[serde(flatten)]
@@ -335,13 +354,20 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> tracing_subscriber::Layer<S> for La
                 })
             })
             .unwrap_or(Vec::new());
+
+        #[cfg(feature = "dynamic_labels")]
+        let formatted_labels = {
+            let mut label_selector = LabelSelectorVisitor::new(&self.dynamic_labels);
+            event.record(&mut label_selector);
+            label_selector.finish(*meta.level())
+        };
         // TODO: Anything useful to do when the capacity has been reached?
+        // (the capacity is quite large so if it happens we have bigger problems)
         let _ = self.sender.try_send(Some(LokiEvent {
             trigger_send: !meta.target().starts_with("tracing_loki"),
             timestamp,
-            level: *meta.level(),
             message: serde_json::to_string(&SerializedEvent {
-                event: SerializeEventFieldMapStrippingLog(event),
+                event: SerializeEventFieldMapStrippingLogAndKeys(event, &self.dynamic_labels),
                 extra_fields: &self.extra_fields,
                 span_fields,
                 _spans: &spans,
@@ -351,6 +377,12 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> tracing_subscriber::Layer<S> for La
                 _line: meta.line(),
             })
             .expect("json serialization shouldn't fail"),
+
+            #[cfg(not(feature = "dynamic_labels"))]
+            level: *meta.level(),
+
+            #[cfg(feature = "dynamic_labels")]
+            formatted_labels,
         }));
     }
 }
@@ -442,7 +474,14 @@ impl error::Error for BadRedirect {}
 pub struct BackgroundTask {
     loki_url: Url,
     receiver: ReceiverStream<Option<LokiEvent>>,
-    queues: LevelMap<SendQueue>,
+
+    #[cfg(not(feature = "dynamic_labels"))]
+    level_queues: LevelMap<SendQueue>,
+
+    #[cfg(feature = "dynamic_labels")]
+    label_queues: LabelMap<SendQueue>,
+
+    base_labels: FormattedLabels,
     buffer: Buffer,
     http_client: reqwest::Client,
     backoff_count: u32,
@@ -464,7 +503,14 @@ impl BackgroundTask {
             loki_url: loki_url
                 .join("loki/api/v1/push")
                 .map_err(|_| Error(ErrorI::InvalidLokiUrl))?,
-            queues: LevelMap::from_fn(|level| SendQueue::new(labels.finish(level))),
+
+            #[cfg(not(feature = "dynamic_labels"))]
+            level_queues: LevelMap::from_fn(|level| SendQueue::new(labels.finish(level))),
+
+            #[cfg(feature = "dynamic_labels")]
+            label_queues: LabelMap::new(),
+
+            base_labels: labels.clone(),
             buffer: Buffer::new(),
             http_client: reqwest::Client::builder()
                 .user_agent(concat!(
@@ -501,6 +547,41 @@ impl BackgroundTask {
             cmp::min(backoff_time, Duration::from_secs(600)),
         )
     }
+    /// Takes mut event for perfomance reasons - taking the label out of it
+    fn get_queue_for_event<'a>(&'a mut self, event: &mut LokiEvent) -> &'a mut SendQueue {
+        #[cfg(not(feature = "dynamic_labels"))]
+        let queue = self.level_queues[event.level];
+
+        #[cfg(feature = "dynamic_labels")]
+        let queue = {
+            let joined_labels = self
+                .base_labels
+                .clone()
+                .join_with_finished(mem::take(&mut event.formatted_labels));
+            self.label_queues
+                .get_or_insert(joined_labels.clone(), || SendQueue::new(joined_labels))
+        };
+
+        queue
+    }
+    fn queues_mut(&mut self) -> impl Iterator<Item = &mut SendQueue> {
+        #[cfg(not(feature = "dynamic_labels"))]
+        let queues = self.level_queues.values_mut();
+
+        #[cfg(feature = "dynamic_labels")]
+        let queues = self.label_queues.values_mut();
+
+        queues
+    }
+    fn queues(&self) -> impl Iterator<Item = &SendQueue> {
+        #[cfg(not(feature = "dynamic_labels"))]
+        let queues = self.level_queues.values();
+
+        #[cfg(feature = "dynamic_labels")]
+        let queues = self.label_queues.values();
+
+        queues
+    }
 }
 
 impl Future for BackgroundTask {
@@ -510,7 +591,7 @@ impl Future for BackgroundTask {
 
         while let Poll::Ready(maybe_maybe_item) = Pin::new(&mut self.receiver).poll_next(cx) {
             match maybe_maybe_item {
-                Some(Some(item)) => self.queues[item.level].push(item),
+                Some(Some(mut item)) => self.get_queue_for_event(&mut item).push(item),
                 Some(None) => self.quitting = true, // Explicit close.
                 None => self.quitting = true,       // The sender was dropped.
             }
@@ -541,7 +622,7 @@ impl Future for BackgroundTask {
                                 tracing::subscriber::set_default(NoSubscriber::default());
                             if drop_outstanding {
                                 let num_dropped: usize =
-                                    self.queues.values_mut().map(|q| q.drop_outstanding()).sum();
+                                    self.queues_mut().map(|q| q.drop_outstanding()).sum();
                                 drop(default_guard);
                                 tracing::error!(
                                     num_dropped,
@@ -557,7 +638,7 @@ impl Future for BackgroundTask {
                             self.backoff_count = 0;
                         }
                         let res = res.map_err(|_| ());
-                        for q in self.queues.values_mut() {
+                        for q in self.queues_mut() {
                             q.on_send_result(res);
                         }
                         self.send_task = None;
@@ -567,11 +648,10 @@ impl Future for BackgroundTask {
             }
             if self.send_task.is_none()
                 && !backing_off
-                && self.queues.values().any(|q| q.should_send())
+                && self.queues().any(|q| q.should_send())
             {
                 let streams = self
-                    .queues
-                    .values_mut()
+                    .queues_mut()
                     .map(|q| q.prepare_sending())
                     .filter(|s| !s.entries.is_empty())
                     .collect();

--- a/src/log_support.rs
+++ b/src/log_support.rs
@@ -1,6 +1,7 @@
 use serde::ser::SerializeMap;
 use serde::Serialize;
 use serde::Serializer;
+use std::collections::HashMap;
 use std::error;
 use std::fmt;
 use tracing_core::field::Visit;
@@ -8,65 +9,67 @@ use tracing_core::Event;
 use tracing_core::Field;
 use tracing_serde::SerdeMapVisitor;
 
-pub struct SerializeEventFieldMapStrippingLog<'a>(pub &'a Event<'a>);
+use crate::labels::ValidatedLabel;
 
-impl<'a> Serialize for SerializeEventFieldMapStrippingLog<'a> {
+pub struct SerializeEventFieldMapStrippingLogAndKeys<'a>(pub &'a Event<'a>, pub&'a HashMap<String, ValidatedLabel>);
+
+impl<'a> Serialize for SerializeEventFieldMapStrippingLogAndKeys<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let len = self.0.fields().count();
         let serializer = serializer.serialize_map(Some(len))?;
-        let mut visitor = SerdeMapVisitorStrippingLog::new(serializer);
+        let mut visitor = SerdeMapVisitorStrippingLogAndKeys::new(serializer, self.1);
         self.0.record(&mut visitor);
         visitor.finish()
     }
 }
 
-struct SerdeMapVisitorStrippingLog<S: SerializeMap>(SerdeMapVisitor<S>);
+struct SerdeMapVisitorStrippingLogAndKeys<'a, S: SerializeMap>(SerdeMapVisitor<S>, &'a HashMap<String, ValidatedLabel>);
 
-impl<S: SerializeMap> SerdeMapVisitorStrippingLog<S> {
-    fn new(serializer: S) -> SerdeMapVisitorStrippingLog<S> {
-        SerdeMapVisitorStrippingLog(SerdeMapVisitor::new(serializer))
+impl<'a, S: SerializeMap> SerdeMapVisitorStrippingLogAndKeys<'a, S> {
+    fn new(serializer: S, strip_keys: &'a HashMap<String, ValidatedLabel>) -> Self {
+        Self(SerdeMapVisitor::new(serializer), strip_keys)
     }
-    fn ignore(field: &Field) -> bool {
-        field.name().starts_with("log.")
+    fn ignore(&self, field: &Field) -> bool {
+        field.name().starts_with("log.") || self.1.contains_key(field.name())
     }
     fn finish(self) -> Result<S::Ok, S::Error> {
         self.0.finish()
     }
 }
 
-impl<S: SerializeMap> Visit for SerdeMapVisitorStrippingLog<S> {
+impl<'a, S: SerializeMap> Visit for SerdeMapVisitorStrippingLogAndKeys<'a, S> {
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        if !Self::ignore(field) {
+        if !self.ignore(field) {
             self.0.record_debug(field, value);
         }
     }
     fn record_f64(&mut self, field: &Field, value: f64) {
-        if !Self::ignore(field) {
+        if !self.ignore(field) {
             self.0.record_f64(field, value);
         }
     }
     fn record_i64(&mut self, field: &Field, value: i64) {
-        if !Self::ignore(field) {
+        if !self.ignore(field) {
             self.0.record_i64(field, value);
         }
     }
     fn record_u64(&mut self, field: &Field, value: u64) {
-        if !Self::ignore(field) {
+        if !self.ignore(field) {
             self.0.record_u64(field, value);
         }
     }
     fn record_bool(&mut self, field: &Field, value: bool) {
-        if !Self::ignore(field) {
+        if !self.ignore(field) {
             self.0.record_bool(field, value);
         }
     }
     fn record_str(&mut self, field: &Field, value: &str) {
-        if !Self::ignore(field) {
+        if !self.ignore(field) {
             self.0.record_str(field, value);
         }
     }
     fn record_error(&mut self, field: &Field, value: &(dyn error::Error + 'static)) {
-        if !Self::ignore(field) {
+        if !self.ignore(field) {
             self.0.record_error(field, value);
         }
     }


### PR DESCRIPTION
For a project I'm working on I needed to set labels based on tracing fields. This PR adds support for that (as "dynamic labels") gated behind a default feature. When the feature is disabled, the execution flow is almost unchanged. The code has been tested inside an application both with the feature enabled and disabled and performs as expected.

A single unrelated change here is making the bounded event queue quite a bit larger, into "you have bigger problems if you overflow this" territory - i just found the initial value a bit restrictive. I can remove / split this change into a separate PR if you consider it appropriate.