### PR TITLE
fix: changed internal architecture to avoid high memory usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +194,19 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -379,9 +404,19 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.120"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -453,6 +488,15 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "native-tls"
@@ -720,7 +764,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -762,6 +806,12 @@ dependencies = [
  "lazy_static",
  "winapi",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -881,6 +931,15 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "syn"
@@ -1059,6 +1118,7 @@ dependencies = [
 name = "tracing-loki"
 version = "0.2.5"
 dependencies = [
+ "flume",
  "loki-api",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tracing-log = "0.1.2"
 tracing-serde = "0.1.3"
 tracing-subscriber = "0.3.9"
 url = "2.2.2"
+flume = "0.11.1"
 
 [dev-dependencies]
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ async fn main() -> Result<(), tracing_loki::Error> {
 
     // The background task needs to be spawned so the logs actually get
     // delivered.
-    tokio::spawn(task);
+    tokio::spawn(task.start());
 
     tracing::info!(
         task = "tracing_setup",

--- a/examples/builder.rs
+++ b/examples/builder.rs
@@ -18,7 +18,7 @@ fn tracing_setup() -> Result<(), Box<dyn Error>> {
         .with(layer)
         .with(Layer::new())
         .init();
-    tokio::spawn(task);
+    tokio::spawn(task.start());
     Ok(())
 }
 

--- a/examples/layer.rs
+++ b/examples/layer.rs
@@ -19,7 +19,7 @@ fn tracing_setup() -> Result<(), Box<dyn Error>> {
         .with(layer)
         .with(Layer::new())
         .init();
-    tokio::spawn(task);
+    tokio::spawn(task.start());
     Ok(())
 }
 

--- a/examples/shutdown.rs
+++ b/examples/shutdown.rs
@@ -19,7 +19,7 @@ fn tracing_setup(
         .with(layer)
         .with(Layer::new())
         .init();
-    Ok((controller, tokio::spawn(task)))
+    Ok((controller, tokio::spawn(task.start())))
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //!     // The background task needs to be spawned so the logs actually get
 //!     // delivered.
-//!     tokio::spawn(task);
+//!     tokio::spawn(task.start());
 //!
 //!     tracing::info!(
 //!         task = "tracing_setup",
@@ -53,24 +53,16 @@ compile_error!(
 /// Use this to avoid depending on a potentially-incompatible `url` version yourself.
 pub extern crate url;
 
+use flume::{Receiver, Sender};
 use loki_api::logproto as loki;
 use loki_api::prost;
 use serde::Serialize;
-use std::cmp;
 use std::collections::HashMap;
 use std::error;
 use std::fmt;
-use std::future::Future;
 use std::mem;
-use std::pin::Pin;
-use std::task::Context;
-use std::task::Poll;
 use std::time::Duration;
 use std::time::SystemTime;
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
-use tokio_stream::Stream;
-use tracing::instrument::WithSubscriber;
 use tracing_core::field::Field;
 use tracing_core::field::Visit;
 use tracing_core::span::Attributes;
@@ -87,7 +79,6 @@ use url::Url;
 use labels::FormattedLabels;
 use level_map::LevelMap;
 use log_support::SerializeEventFieldMapStrippingLog;
-use no_subscriber::NoSubscriber;
 use ErrorInner as ErrorI;
 
 pub use builder::builder;
@@ -103,11 +94,8 @@ mod no_subscriber;
 #[doc = include_str!("../README.md")]
 struct ReadmeDoctests;
 
-fn event_channel() -> (
-    mpsc::Sender<Option<LokiEvent>>,
-    mpsc::Receiver<Option<LokiEvent>>,
-) {
-    mpsc::channel(512)
+fn event_channel() -> (Sender<Option<LokiEvent>>, Receiver<Option<LokiEvent>>) {
+    flume::bounded(512)
 }
 
 /// The error type for constructing a [`Layer`].
@@ -195,7 +183,7 @@ impl fmt::Display for ErrorInner {
 ///
 ///     // The background task needs to be spawned so the logs actually get
 ///     // delivered.
-///     tokio::spawn(task);
+///     tokio::spawn(task.start());
 ///
 ///     tracing::info!(
 ///         task = "tracing_setup",
@@ -230,9 +218,10 @@ pub fn layer(
 /// See the crate's root documentation for an example.
 pub struct Layer {
     extra_fields: HashMap<String, String>,
-    sender: mpsc::Sender<Option<LokiEvent>>,
+    sender: Sender<Option<LokiEvent>>,
 }
 
+#[allow(dead_code)]
 struct LokiEvent {
     trigger_send: bool,
     timestamp: SystemTime,
@@ -378,18 +367,7 @@ impl SendQueue {
         self.sending.clear();
         len
     }
-    fn on_send_result(&mut self, result: Result<(), ()>) {
-        match result {
-            Ok(()) => self.sending.clear(),
-            Err(()) => {
-                self.sending.append(&mut self.to_send);
-                mem::swap(&mut self.sending, &mut self.to_send);
-            }
-        }
-    }
-    fn should_send(&self) -> bool {
-        self.to_send.iter().any(|e| e.trigger_send)
-    }
+
     fn prepare_sending(&mut self) -> loki::StreamAdapter {
         if !self.sending.is_empty() {
             panic!("can only prepare sending while no request is in flight");
@@ -441,26 +419,23 @@ impl error::Error for BadRedirect {}
 /// See the crate's root documentation for an example.
 pub struct BackgroundTask {
     loki_url: Url,
-    receiver: ReceiverStream<Option<LokiEvent>>,
+    receiver: Receiver<Option<LokiEvent>>,
     queues: LevelMap<SendQueue>,
     buffer: Buffer,
     http_client: reqwest::Client,
-    backoff_count: u32,
-    backoff: Option<Pin<Box<tokio::time::Sleep>>>,
-    quitting: bool,
-    send_task:
-        Option<Pin<Box<dyn Future<Output = Result<(), Box<dyn error::Error>>> + Send + 'static>>>,
+    backoff: Duration,
 }
 
 impl BackgroundTask {
     fn new(
         loki_url: Url,
         http_headers: reqwest::header::HeaderMap,
-        receiver: mpsc::Receiver<Option<LokiEvent>>,
+        receiver: Receiver<Option<LokiEvent>>,
         labels: &FormattedLabels,
+        backoff: Duration,
     ) -> Result<BackgroundTask, Error> {
         Ok(BackgroundTask {
-            receiver: ReceiverStream::new(receiver),
+            receiver,
             loki_url: loki_url
                 .join("loki/api/v1/push")
                 .map_err(|_| Error(ErrorI::InvalidLokiUrl))?,
@@ -483,126 +458,54 @@ impl BackgroundTask {
                 }))
                 .build()
                 .expect("reqwest client builder"),
-            backoff_count: 0,
-            backoff: None,
-            quitting: false,
-            send_task: None,
+            backoff,
         })
     }
-    fn backoff_time(&self) -> (bool, Duration) {
-        let backoff_time = if self.backoff_count >= 1 {
-            Duration::from_millis(
-                500u64
-                    .checked_shl(self.backoff_count - 1)
-                    .unwrap_or(u64::MAX),
-            )
-        } else {
-            Duration::from_millis(0)
-        };
-        (
-            backoff_time >= Duration::from_secs(30),
-            cmp::min(backoff_time, Duration::from_secs(600)),
-        )
-    }
-}
 
-impl Future for BackgroundTask {
-    type Output = ();
-    fn poll(mut self: Pin<&mut BackgroundTask>, cx: &mut Context<'_>) -> Poll<()> {
-        let mut default_guard = tracing::subscriber::set_default(NoSubscriber::default());
-
-        while let Poll::Ready(maybe_maybe_item) = Pin::new(&mut self.receiver).poll_next(cx) {
-            match maybe_maybe_item {
-                Some(Some(item)) => self.queues[item.level].push(item),
-                Some(None) => self.quitting = true, // Explicit close.
-                None => self.quitting = true,       // The sender was dropped.
-            }
-        }
-
-        let mut backing_off = if let Some(backoff) = &mut self.backoff {
-            matches!(Pin::new(backoff).poll(cx), Poll::Pending)
-        } else {
-            false
-        };
-        if !backing_off {
-            self.backoff = None;
-        }
+    /// Does something
+    pub async fn start(mut self) {
         loop {
-            if let Some(send_task) = &mut self.send_task {
-                match Pin::new(send_task).poll(cx) {
-                    Poll::Ready(res) => {
-                        if let Err(e) = &res {
-                            let (drop_outstanding, backoff_time) = self.backoff_time();
-                            drop(default_guard);
-                            tracing::error!(
-                                error_count = self.backoff_count + 1,
-                                ?backoff_time,
-                                error = %e,
-                                "couldn't send logs to loki",
-                            );
-                            default_guard =
-                                tracing::subscriber::set_default(NoSubscriber::default());
-                            if drop_outstanding {
-                                let num_dropped: usize =
-                                    self.queues.values_mut().map(|q| q.drop_outstanding()).sum();
-                                drop(default_guard);
-                                tracing::error!(
-                                    num_dropped,
-                                    "dropped outstanding messages due to sending errors",
-                                );
-                                default_guard =
-                                    tracing::subscriber::set_default(NoSubscriber::default());
-                            }
-                            self.backoff = Some(Box::pin(tokio::time::sleep(backoff_time)));
-                            self.backoff_count += 1;
-                            backing_off = true;
-                        } else {
-                            self.backoff_count = 0;
-                        }
-                        let res = res.map_err(|_| ());
-                        for q in self.queues.values_mut() {
-                            q.on_send_result(res);
-                        }
-                        self.send_task = None;
+            // get everything form the channel
+            while let Ok(msg) = self.receiver.try_recv() {
+                match msg {
+                    Some(event) => {
+                        // push somewhere
+                        self.queues[event.level].push(event);
                     }
-                    Poll::Pending => {}
+                    None => {
+                        // explicit exit
+                        return;
+                    }
                 }
             }
-            if self.send_task.is_none()
-                && !backing_off
-                && self.queues.values().any(|q| q.should_send())
+            // send the things to loki
+            let streams = self
+                .queues
+                .values_mut()
+                .map(|q| q.prepare_sending())
+                .filter(|s| !s.entries.is_empty())
+                .collect();
+            let body = self
+                .buffer
+                .encode(&loki::PushRequest { streams })
+                .to_owned();
+            let request_builder = self.http_client.post(self.loki_url.clone());
+            if let Ok(res) = request_builder
+                .header(reqwest::header::CONTENT_TYPE, "application/x-snappy")
+                .body(body)
+                .send()
+                .await
             {
-                let streams = self
-                    .queues
-                    .values_mut()
-                    .map(|q| q.prepare_sending())
-                    .filter(|s| !s.entries.is_empty())
-                    .collect();
-                let body = self
-                    .buffer
-                    .encode(&loki::PushRequest { streams })
-                    .to_owned();
-                let request_builder = self.http_client.post(self.loki_url.clone());
-                self.send_task = Some(Box::pin(
-                    async move {
-                        request_builder
-                            .header(reqwest::header::CONTENT_TYPE, "application/x-snappy")
-                            .body(body)
-                            .send()
-                            .await?
-                            .error_for_status()?;
-                        Ok(())
-                    }
-                    .with_subscriber(NoSubscriber::default()),
-                ));
-            } else {
-                break;
+                if let Err(e) = res.error_for_status() {
+                    tracing::error!("Cannot send {e:?}");
+                }
             }
-        }
-        if self.quitting && self.send_task.is_none() {
-            Poll::Ready(())
-        } else {
-            Poll::Pending
+            // drop sent messages
+            self.queues.values_mut().for_each(|q| {
+                q.drop_outstanding();
+            });
+            // sleep before next iteration
+            tokio::time::sleep(self.backoff).await;
         }
     }
 }
@@ -646,13 +549,13 @@ impl Buffer {
 ///
 /// It'll still try to send all available data and then quit.
 pub struct BackgroundTaskController {
-    sender: mpsc::Sender<Option<LokiEvent>>,
+    sender: Sender<Option<LokiEvent>>,
 }
 
 impl BackgroundTaskController {
     /// Shut down the associated `BackgroundTask`.
     pub async fn shutdown(&self) {
         // Ignore the error. If no one is listening, it already shut down.
-        let _ = self.sender.send(None).await;
+        let _ = self.sender.send_async(None).await;
     }
 }


### PR DESCRIPTION
Based on the finding form #9.

RAM usage (10minutes, same load on the process, same log level) 

before:
<img width="976" alt="Screenshot 2024-12-04 at 15 49 29" src="https://github.com/user-attachments/assets/07994593-b80f-4aa0-815f-f3b92494b1c2">

logs on loki:
<img width="846" alt="Screenshot 2024-12-04 at 15 52 07" src="https://github.com/user-attachments/assets/914d24fc-4838-4959-8ae4-3f2a2c3da87e">

after:

<img width="859" alt="Screenshot 2024-12-04 at 15 37 06" src="https://github.com/user-attachments/assets/d0372e01-dca1-4223-87d7-0b549808c9ad">
logs on loki:
<img width="833" alt="Screenshot 2024-12-04 at 15 53 16" src="https://github.com/user-attachments/assets/4c16c1fa-a6c4-4b38-a5aa-9416f746e250">

its around 1/10th with this patch, for the same amount of data pushed to Loki.
I replaced `tokio::mpsc` with `flume` because the latter does not take `&mut self` in the `try_recv()`.
The backoff time is configurable, I can make also the channel size configurable, still via the builder.


I introduced an API breaking change `task::spawn(task.start()` instead of `task::spawn(task)`, but I think I can make it compatible just a matter of playing a bit with the builder.




I can provide macOS Instrument traces if needed, did not upload them as they are 100s of MBs.



