### PR TITLE
Use long-form headers instead of shortcut

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -17,7 +17,11 @@ pub fn builder() -> Builder {
     let mut http_headers = reqwest::header::HeaderMap::new();
     http_headers.insert(
         reqwest::header::CONTENT_TYPE,
-        reqwest::header::HeaderValue::from_static("application/x-snappy"),
+        reqwest::header::HeaderValue::from_static("application/x-protobuf"),
+    );
+    http_headers.insert(
+        reqwest::header::CONTENT_ENCODING,
+        reqwest::header::HeaderValue::from_static("snappy"),
     );
     Builder {
         labels: FormattedLabels::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -584,7 +584,8 @@ impl Future for BackgroundTask {
                 self.send_task = Some(Box::pin(
                     async move {
                         request_builder
-                            .header(reqwest::header::CONTENT_TYPE, "application/x-snappy")
+                            .header(reqwest::header::CONTENT_TYPE, "application/x-protobuf")
+                            .header(reqwest::header::CONTENT_ENCODING, "snappy")
                             .body(body)
                             .send()
                             .await?


### PR DESCRIPTION
Replace the shortcut header "Content-type: application/x-snappy" with the proper two headers (Content-type: "application/x-protobuf" and Content-encoding: "snappy") it's meant to represent.

This enables compatibility with OpenTelemetry's Collector [Loki receiver plugin](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/lokireceiver) while maintaining compatibility with Loki itself (tested it against Loki v3.7.1, which is the latest version as of this moment).